### PR TITLE
Removed query string params for App Search endpoints

### DIFF
--- a/src/AppSearch/Endpoints.php
+++ b/src/AppSearch/Endpoints.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace Elastic\EnterpriseSearch\AppSearch;
 
 use Elastic\EnterpriseSearch\AbstractEndpoints;
+use Elastic\EnterpriseSearch\AppSearch\Request;
 use Elastic\EnterpriseSearch\Response\Response;
 
 /**

--- a/src/AppSearch/Request/AddMetaEngineSource.php
+++ b/src/AppSearch/Request/AddMetaEngineSource.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Add a source engine to an existing meta engine
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/meta-engines.html#meta-engines-add-source-engines
  */
 class AddMetaEngineSource extends Request
 {

--- a/src/AppSearch/Request/CreateCuration.php
+++ b/src/AppSearch/Request/CreateCuration.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Create a new curation
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/curations.html#curations-create
  */
 class CreateCuration extends Request
 {
@@ -34,7 +36,8 @@ class CreateCuration extends Request
 	{
 		$this->method = 'POST';
 		$engine_name = urlencode($engineName);
-		$this->queryParams['queries[]'] = $queries;
+		$this->headers['Content-Type'] = 'application/json';
+		$this->body['queries'] = $queries;
 		$this->path = "/api/as/v1/engines/$engine_name/curations";
 	}
 
@@ -44,7 +47,7 @@ class CreateCuration extends Request
 	 */
 	public function setPromotedDocIds(array $promotedDocIds): self
 	{
-		$this->queryParams['promoted[]'] = $promotedDocIds;
+		$this->body['promoted'] = $promotedDocIds;
 		return $this;
 	}
 
@@ -54,7 +57,7 @@ class CreateCuration extends Request
 	 */
 	public function setHiddenDocIds(array $hiddenDocIds): self
 	{
-		$this->queryParams['hidden[]'] = $hiddenDocIds;
+		$this->body['hidden'] = $hiddenDocIds;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/CreateEngine.php
+++ b/src/AppSearch/Request/CreateEngine.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Creates a new engine
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/engines.html#engines-create
  */
 class CreateEngine extends Request
 {
@@ -32,7 +34,8 @@ class CreateEngine extends Request
 	public function __construct(string $engineName)
 	{
 		$this->method = 'POST';
-		$this->queryParams['name'] = $engineName;
+		$this->headers['Content-Type'] = 'application/json';
+		$this->body['name'] = $engineName;
 		$this->path = "/api/as/v1/engines";
 	}
 
@@ -42,7 +45,7 @@ class CreateEngine extends Request
 	 */
 	public function setLanguage(string $language): self
 	{
-		$this->queryParams['language'] = $language;
+		$this->body['language'] = $language;
 		return $this;
 	}
 
@@ -52,7 +55,7 @@ class CreateEngine extends Request
 	 */
 	public function setType(string $type): self
 	{
-		$this->queryParams['type'] = $type;
+		$this->body['type'] = $type;
 		return $this;
 	}
 
@@ -62,7 +65,7 @@ class CreateEngine extends Request
 	 */
 	public function setSourceEngines(array $sourceEngines): self
 	{
-		$this->queryParams['source_engines[]'] = $sourceEngines;
+		$this->body['source_engines'] = $sourceEngines;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/CreateSynonymSet.php
+++ b/src/AppSearch/Request/CreateSynonymSet.php
@@ -23,7 +23,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Create a new synonym set
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/synonyms.html#synonyms-create
  */
 class CreateSynonymSet extends Request
 {

--- a/src/AppSearch/Request/DeleteCuration.php
+++ b/src/AppSearch/Request/DeleteCuration.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Delete a curation by ID
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/curations.html#curations-destroy
  */
 class DeleteCuration extends Request
 {

--- a/src/AppSearch/Request/DeleteDocuments.php
+++ b/src/AppSearch/Request/DeleteDocuments.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Delete documents by ID
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/documents.html#documents-delete
  */
 class DeleteDocuments extends Request
 {

--- a/src/AppSearch/Request/DeleteEngine.php
+++ b/src/AppSearch/Request/DeleteEngine.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Delete an engine by name
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/engines.html#engines-delete
  */
 class DeleteEngine extends Request
 {

--- a/src/AppSearch/Request/DeleteMetaEngineSource.php
+++ b/src/AppSearch/Request/DeleteMetaEngineSource.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Delete a source engine from a meta engine
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/meta-engines.html#meta-engines-remove-source-engines
  */
 class DeleteMetaEngineSource extends Request
 {

--- a/src/AppSearch/Request/DeleteSynonymSet.php
+++ b/src/AppSearch/Request/DeleteSynonymSet.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Delete a synonym set by ID
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/synonyms.html#synonyms-delete
  */
 class DeleteSynonymSet extends Request
 {

--- a/src/AppSearch/Request/GetApiLogs.php
+++ b/src/AppSearch/Request/GetApiLogs.php
@@ -45,21 +45,21 @@ class GetApiLogs extends Request
 
 
 	/**
-	 * @param int $toDate The page to fetch. Defaults to 1
+	 * @param int $currentPage The page to fetch. Defaults to 1
 	 */
-	public function setCurrentPage(int $toDate): self
+	public function setCurrentPage(int $currentPage): self
 	{
-		$this->body['filters']['date']['to'] = $toDate;
+		$this->body['page']['current'] = $currentPage;
 		return $this;
 	}
 
 
 	/**
-	 * @param int $toDate The number of results per page
+	 * @param int $pageSize The number of results per page
 	 */
-	public function setPageSize(int $toDate): self
+	public function setPageSize(int $pageSize): self
 	{
-		$this->body['filters']['date']['to'] = $toDate;
+		$this->body['page']['size'] = $pageSize;
 		return $this;
 	}
 

--- a/src/AppSearch/Request/GetApiLogs.php
+++ b/src/AppSearch/Request/GetApiLogs.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * The API Log displays API request and response data at the Engine level
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/api-logs.html
  */
 class GetApiLogs extends Request
 {
@@ -35,28 +37,29 @@ class GetApiLogs extends Request
 	{
 		$this->method = 'GET';
 		$engine_name = urlencode($engineName);
-		$this->queryParams['filters[date][from]'] = $fromDate;
-		$this->queryParams['filters[date][to]'] = $toDate;
+		$this->headers['Content-Type'] = 'application/json';
+		$this->body['filters']['date']['from'] = $fromDate;
+		$this->body['filters']['date']['to'] = $toDate;
 		$this->path = "/api/as/v1/engines/$engine_name/logs/api";
 	}
 
 
 	/**
-	 * @param int $currentPage The page to fetch. Defaults to 1
+	 * @param int $toDate The page to fetch. Defaults to 1
 	 */
-	public function setCurrentPage(int $currentPage): self
+	public function setCurrentPage(int $toDate): self
 	{
-		$this->queryParams['page[current]'] = $currentPage;
+		$this->body['filters']['date']['to'] = $toDate;
 		return $this;
 	}
 
 
 	/**
-	 * @param int $pageSize The number of results per page
+	 * @param int $toDate The number of results per page
 	 */
-	public function setPageSize(int $pageSize): self
+	public function setPageSize(int $toDate): self
 	{
-		$this->queryParams['page[size]'] = $pageSize;
+		$this->body['filters']['date']['to'] = $toDate;
 		return $this;
 	}
 
@@ -66,7 +69,7 @@ class GetApiLogs extends Request
 	 */
 	public function setQuery(string $query): self
 	{
-		$this->queryParams['query'] = $query;
+		$this->body['query'] = $query;
 		return $this;
 	}
 
@@ -76,7 +79,7 @@ class GetApiLogs extends Request
 	 */
 	public function setHttpStatusFilter(string $httpStatusFilter): self
 	{
-		$this->queryParams['filters[status]'] = $httpStatusFilter;
+		$this->body['filters']['status'] = $httpStatusFilter;
 		return $this;
 	}
 
@@ -86,7 +89,7 @@ class GetApiLogs extends Request
 	 */
 	public function setHttpMethodFilter(string $httpMethodFilter): self
 	{
-		$this->queryParams['filters[method]'] = $httpMethodFilter;
+		$this->body['filters']['method'] = $httpMethodFilter;
 		return $this;
 	}
 
@@ -96,7 +99,7 @@ class GetApiLogs extends Request
 	 */
 	public function setSortDirection(string $sortDirection): self
 	{
-		$this->queryParams['sort_direction'] = $sortDirection;
+		$this->body['sort_direction'] = $sortDirection;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/GetCountAnalytics.php
+++ b/src/AppSearch/Request/GetCountAnalytics.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Returns the number of clicks and total number of queries over a period
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/counts.html
  */
 class GetCountAnalytics extends Request
 {
@@ -33,6 +35,7 @@ class GetCountAnalytics extends Request
 	{
 		$this->method = 'GET';
 		$engine_name = urlencode($engineName);
+		$this->headers['Content-Type'] = 'application/json';
 		$this->path = "/api/as/v1/engines/$engine_name/analytics/counts";
 	}
 
@@ -42,7 +45,7 @@ class GetCountAnalytics extends Request
 	 */
 	public function setFilters(array $filters): self
 	{
-		$this->queryParams['filters'] = $filters;
+		$this->body['filters'] = $filters;
 		return $this;
 	}
 
@@ -52,7 +55,7 @@ class GetCountAnalytics extends Request
 	 */
 	public function setInterval(string $interval): self
 	{
-		$this->queryParams['interval'] = $interval;
+		$this->body['interval'] = $interval;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/GetCuration.php
+++ b/src/AppSearch/Request/GetCuration.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Retrieve a curation by ID
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/curations.html#curations-read
  */
 class GetCuration extends Request
 {

--- a/src/AppSearch/Request/GetDocuments.php
+++ b/src/AppSearch/Request/GetDocuments.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Retrieves one or more documents by ID
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/documents.html#documents-get
  */
 class GetDocuments extends Request
 {

--- a/src/AppSearch/Request/GetEngine.php
+++ b/src/AppSearch/Request/GetEngine.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Retrieves an engine by name
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/engines.html#engines-get
  */
 class GetEngine extends Request
 {

--- a/src/AppSearch/Request/GetSchema.php
+++ b/src/AppSearch/Request/GetSchema.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Retrieve current schema for the engine
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/schema.html#schema-read
  */
 class GetSchema extends Request
 {

--- a/src/AppSearch/Request/GetSearchSettings.php
+++ b/src/AppSearch/Request/GetSearchSettings.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Retrieve current search settings for the engine
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/search-settings.html#search-settings-show
  */
 class GetSearchSettings extends Request
 {

--- a/src/AppSearch/Request/GetSynonymSet.php
+++ b/src/AppSearch/Request/GetSynonymSet.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Retrieve a synonym set by ID
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/synonyms.html#synonyms-list-one
  */
 class GetSynonymSet extends Request
 {

--- a/src/AppSearch/Request/GetTopClicksAnalytics.php
+++ b/src/AppSearch/Request/GetTopClicksAnalytics.php
@@ -51,21 +51,21 @@ class GetTopClicksAnalytics extends Request
 
 
 	/**
-	 * @param int $query The page to fetch. Defaults to 1
+	 * @param int $currentPage The page to fetch. Defaults to 1
 	 */
-	public function setCurrentPage(int $query): self
+	public function setCurrentPage(int $currentPage): self
 	{
-		$this->body['query'] = $query;
+		$this->body['page']['current'] = $currentPage;
 		return $this;
 	}
 
 
 	/**
-	 * @param int $query The number of results per page
+	 * @param int $pageSize The number of results per page
 	 */
-	public function setPageSize(int $query): self
+	public function setPageSize(int $pageSize): self
 	{
-		$this->body['query'] = $query;
+		$this->body['page']['size'] = $pageSize;
 		return $this;
 	}
 

--- a/src/AppSearch/Request/GetTopClicksAnalytics.php
+++ b/src/AppSearch/Request/GetTopClicksAnalytics.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Returns the number of clicks received by a document in descending order
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/clicks.html
  */
 class GetTopClicksAnalytics extends Request
 {
@@ -33,6 +35,7 @@ class GetTopClicksAnalytics extends Request
 	{
 		$this->method = 'GET';
 		$engine_name = urlencode($engineName);
+		$this->headers['Content-Type'] = 'application/json';
 		$this->path = "/api/as/v1/engines/$engine_name/analytics/clicks";
 	}
 
@@ -42,27 +45,27 @@ class GetTopClicksAnalytics extends Request
 	 */
 	public function setQuery(string $query): self
 	{
-		$this->queryParams['query'] = $query;
+		$this->body['query'] = $query;
 		return $this;
 	}
 
 
 	/**
-	 * @param int $currentPage The page to fetch. Defaults to 1
+	 * @param int $query The page to fetch. Defaults to 1
 	 */
-	public function setCurrentPage(int $currentPage): self
+	public function setCurrentPage(int $query): self
 	{
-		$this->queryParams['page[current]'] = $currentPage;
+		$this->body['query'] = $query;
 		return $this;
 	}
 
 
 	/**
-	 * @param int $pageSize The number of results per page
+	 * @param int $query The number of results per page
 	 */
-	public function setPageSize(int $pageSize): self
+	public function setPageSize(int $query): self
 	{
-		$this->queryParams['page[size]'] = $pageSize;
+		$this->body['query'] = $query;
 		return $this;
 	}
 
@@ -72,7 +75,7 @@ class GetTopClicksAnalytics extends Request
 	 */
 	public function setFilters(array $filters): self
 	{
-		$this->queryParams['filters[]'] = $filters;
+		$this->body['filters'] = $filters;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/GetTopQueriesAnalytics.php
+++ b/src/AppSearch/Request/GetTopQueriesAnalytics.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Returns queries analytics by usage count
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/queries.html#queries-top-queries
  */
 class GetTopQueriesAnalytics extends Request
 {
@@ -33,6 +35,7 @@ class GetTopQueriesAnalytics extends Request
 	{
 		$this->method = 'GET';
 		$engine_name = urlencode($engineName);
+		$this->headers['Content-Type'] = 'application/json';
 		$this->path = "/api/as/v1/engines/$engine_name/analytics/queries";
 	}
 
@@ -42,7 +45,7 @@ class GetTopQueriesAnalytics extends Request
 	 */
 	public function setCurrentPage(int $currentPage): self
 	{
-		$this->queryParams['page[current]'] = $currentPage;
+		$this->body['query'] = $currentPage;
 		return $this;
 	}
 
@@ -52,7 +55,7 @@ class GetTopQueriesAnalytics extends Request
 	 */
 	public function setPageSize(int $pageSize): self
 	{
-		$this->queryParams['page[size]'] = $pageSize;
+		$this->body['query'] = $pageSize;
 		return $this;
 	}
 
@@ -62,7 +65,7 @@ class GetTopQueriesAnalytics extends Request
 	 */
 	public function setFilters(array $filters): self
 	{
-		$this->queryParams['filters[]'] = $filters;
+		$this->body['filters'] = $filters;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/GetTopQueriesAnalytics.php
+++ b/src/AppSearch/Request/GetTopQueriesAnalytics.php
@@ -45,7 +45,7 @@ class GetTopQueriesAnalytics extends Request
 	 */
 	public function setCurrentPage(int $currentPage): self
 	{
-		$this->body['query'] = $currentPage;
+		$this->body['page']['current'] = $currentPage;
 		return $this;
 	}
 
@@ -55,7 +55,7 @@ class GetTopQueriesAnalytics extends Request
 	 */
 	public function setPageSize(int $pageSize): self
 	{
-		$this->body['query'] = $pageSize;
+		$this->body['page']['size'] = $pageSize;
 		return $this;
 	}
 

--- a/src/AppSearch/Request/IndexDocuments.php
+++ b/src/AppSearch/Request/IndexDocuments.php
@@ -23,7 +23,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Create or update documents
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/documents.html#documents-create
  */
 class IndexDocuments extends Request
 {

--- a/src/AppSearch/Request/ListCurations.php
+++ b/src/AppSearch/Request/ListCurations.php
@@ -45,7 +45,7 @@ class ListCurations extends Request
 	 */
 	public function setCurrentPage(int $currentPage): self
 	{
-		$this->body['query'] = $currentPage;
+		$this->body['page']['current'] = $currentPage;
 		return $this;
 	}
 
@@ -55,7 +55,7 @@ class ListCurations extends Request
 	 */
 	public function setPageSize(int $pageSize): self
 	{
-		$this->body['query'] = $pageSize;
+		$this->body['page']['size'] = $pageSize;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/ListCurations.php
+++ b/src/AppSearch/Request/ListCurations.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Retrieve available curations for the engine
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/curations.html#curations-read
  */
 class ListCurations extends Request
 {
@@ -33,6 +35,7 @@ class ListCurations extends Request
 	{
 		$this->method = 'GET';
 		$engine_name = urlencode($engineName);
+		$this->headers['Content-Type'] = 'application/json';
 		$this->path = "/api/as/v1/engines/$engine_name/curations";
 	}
 
@@ -42,7 +45,7 @@ class ListCurations extends Request
 	 */
 	public function setCurrentPage(int $currentPage): self
 	{
-		$this->queryParams['page[current]'] = $currentPage;
+		$this->body['query'] = $currentPage;
 		return $this;
 	}
 
@@ -52,7 +55,7 @@ class ListCurations extends Request
 	 */
 	public function setPageSize(int $pageSize): self
 	{
-		$this->queryParams['page[size]'] = $pageSize;
+		$this->body['query'] = $pageSize;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/ListDocuments.php
+++ b/src/AppSearch/Request/ListDocuments.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * List all available documents with optional pagination support
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/documents.html#documents-list
  */
 class ListDocuments extends Request
 {
@@ -33,6 +35,7 @@ class ListDocuments extends Request
 	{
 		$this->method = 'GET';
 		$engine_name = urlencode($engineName);
+		$this->headers['Content-Type'] = 'application/json';
 		$this->path = "/api/as/v1/engines/$engine_name/documents/list";
 	}
 
@@ -42,7 +45,7 @@ class ListDocuments extends Request
 	 */
 	public function setCurrentPage(int $currentPage): self
 	{
-		$this->queryParams['page[current]'] = $currentPage;
+		$this->body['query'] = $currentPage;
 		return $this;
 	}
 
@@ -52,7 +55,7 @@ class ListDocuments extends Request
 	 */
 	public function setPageSize(int $pageSize): self
 	{
-		$this->queryParams['page[size]'] = $pageSize;
+		$this->body['query'] = $pageSize;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/ListDocuments.php
+++ b/src/AppSearch/Request/ListDocuments.php
@@ -45,7 +45,7 @@ class ListDocuments extends Request
 	 */
 	public function setCurrentPage(int $currentPage): self
 	{
-		$this->body['query'] = $currentPage;
+		$this->body['page']['current'] = $currentPage;
 		return $this;
 	}
 
@@ -55,7 +55,7 @@ class ListDocuments extends Request
 	 */
 	public function setPageSize(int $pageSize): self
 	{
-		$this->body['query'] = $pageSize;
+		$this->body['page']['size'] = $pageSize;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/ListEngines.php
+++ b/src/AppSearch/Request/ListEngines.php
@@ -22,13 +22,16 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Retrieves all engines with optional pagination support
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/engines.html#engines-list
  */
 class ListEngines extends Request
 {
 	public function __construct()
 	{
 		$this->method = 'GET';
+		$this->headers['Content-Type'] = 'application/json';
 		$this->path = "/api/as/v1/engines";
 	}
 
@@ -38,7 +41,7 @@ class ListEngines extends Request
 	 */
 	public function setCurrentPage(int $currentPage): self
 	{
-		$this->queryParams['page[current]'] = $currentPage;
+		$this->body['page']['current'] = $currentPage;
 		return $this;
 	}
 
@@ -48,7 +51,7 @@ class ListEngines extends Request
 	 */
 	public function setPageSize(int $pageSize): self
 	{
-		$this->queryParams['page[size]'] = $pageSize;
+		$this->body['page']['size'] = $pageSize;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/ListSynonymSets.php
+++ b/src/AppSearch/Request/ListSynonymSets.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Retrieve available synonym sets for the engine
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/synonyms.html#synonyms-get
  */
 class ListSynonymSets extends Request
 {
@@ -33,6 +35,7 @@ class ListSynonymSets extends Request
 	{
 		$this->method = 'GET';
 		$engine_name = urlencode($engineName);
+		$this->headers['Content-Type'] = 'application/json';
 		$this->path = "/api/as/v1/engines/$engine_name/synonyms";
 	}
 
@@ -42,7 +45,7 @@ class ListSynonymSets extends Request
 	 */
 	public function setCurrentPage(int $currentPage): self
 	{
-		$this->queryParams['page[current]'] = $currentPage;
+		$this->body['filters']['date']['to'] = $currentPage;
 		return $this;
 	}
 
@@ -52,7 +55,7 @@ class ListSynonymSets extends Request
 	 */
 	public function setPageSize(int $pageSize): self
 	{
-		$this->queryParams['page[size]'] = $pageSize;
+		$this->body['filters']['date']['to'] = $pageSize;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/ListSynonymSets.php
+++ b/src/AppSearch/Request/ListSynonymSets.php
@@ -45,7 +45,7 @@ class ListSynonymSets extends Request
 	 */
 	public function setCurrentPage(int $currentPage): self
 	{
-		$this->body['filters']['date']['to'] = $currentPage;
+		$this->body['page']['current'] = $currentPage;
 		return $this;
 	}
 
@@ -55,7 +55,7 @@ class ListSynonymSets extends Request
 	 */
 	public function setPageSize(int $pageSize): self
 	{
-		$this->body['filters']['date']['to'] = $pageSize;
+		$this->body['page']['size'] = $pageSize;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/LogClickthrough.php
+++ b/src/AppSearch/Request/LogClickthrough.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Send data about clicked results
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/clickthrough.html
  */
 class LogClickthrough extends Request
 {
@@ -35,8 +37,9 @@ class LogClickthrough extends Request
 	{
 		$this->method = 'POST';
 		$engine_name = urlencode($engineName);
-		$this->queryParams['query'] = $queryText;
-		$this->queryParams['document_id'] = $documentId;
+		$this->headers['Content-Type'] = 'application/json';
+		$this->body['query'] = $queryText;
+		$this->body['document_id'] = $documentId;
 		$this->path = "/api/as/v1/engines/$engine_name/click";
 	}
 
@@ -46,7 +49,7 @@ class LogClickthrough extends Request
 	 */
 	public function setRequestId(string $requestId): self
 	{
-		$this->queryParams['request_id'] = $requestId;
+		$this->body['request_id'] = $requestId;
 		return $this;
 	}
 
@@ -56,7 +59,7 @@ class LogClickthrough extends Request
 	 */
 	public function setTags(array $tags): self
 	{
-		$this->queryParams['tags[]'] = $tags;
+		$this->body['tags'] = $tags;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/MultiSearch.php
+++ b/src/AppSearch/Request/MultiSearch.php
@@ -23,7 +23,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Run several search in the same request
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/multi-search.html
  */
 class MultiSearch extends Request
 {

--- a/src/AppSearch/Request/PutCuration.php
+++ b/src/AppSearch/Request/PutCuration.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Update an existing curation
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/curations.html#curations-update
  */
 class PutCuration extends Request
 {
@@ -36,7 +38,8 @@ class PutCuration extends Request
 		$this->method = 'PUT';
 		$engine_name = urlencode($engineName);
 		$curation_id = urlencode($curationId);
-		$this->queryParams['queries[]'] = $queries;
+		$this->headers['Content-Type'] = 'application/json';
+		$this->body['queries'] = $queries;
 		$this->path = "/api/as/v1/engines/$engine_name/curations/$curation_id";
 	}
 
@@ -46,7 +49,7 @@ class PutCuration extends Request
 	 */
 	public function setPromotedDocIds(array $promotedDocIds): self
 	{
-		$this->queryParams['promoted[]'] = $promotedDocIds;
+		$this->body['promoted'] = $promotedDocIds;
 		return $this;
 	}
 
@@ -56,7 +59,7 @@ class PutCuration extends Request
 	 */
 	public function setHiddenDocIds(array $hiddenDocIds): self
 	{
-		$this->queryParams['hidden[]'] = $hiddenDocIds;
+		$this->body['hidden'] = $hiddenDocIds;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/PutDocuments.php
+++ b/src/AppSearch/Request/PutDocuments.php
@@ -23,7 +23,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Partial update of documents
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/documents.html#documents-partial
  */
 class PutDocuments extends Request
 {

--- a/src/AppSearch/Request/PutSchema.php
+++ b/src/AppSearch/Request/PutSchema.php
@@ -23,7 +23,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Update schema for the current engine
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/schema.html#schema-patch
  */
 class PutSchema extends Request
 {

--- a/src/AppSearch/Request/PutSearchSettings.php
+++ b/src/AppSearch/Request/PutSearchSettings.php
@@ -23,7 +23,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Update search settings for the engine
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/search-settings.html#search-settings-update
  */
 class PutSearchSettings extends Request
 {

--- a/src/AppSearch/Request/PutSynonymSet.php
+++ b/src/AppSearch/Request/PutSynonymSet.php
@@ -23,7 +23,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Update a synonym set by ID
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/synonyms.html#synonyms-update
  */
 class PutSynonymSet extends Request
 {

--- a/src/AppSearch/Request/QuerySuggestion.php
+++ b/src/AppSearch/Request/QuerySuggestion.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Provide relevant query suggestions for incomplete queries
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/query-suggestion.html
  */
 class QuerySuggestion extends Request
 {
@@ -34,7 +36,8 @@ class QuerySuggestion extends Request
 	{
 		$this->method = 'POST';
 		$engine_name = urlencode($engineName);
-		$this->queryParams['query'] = $query;
+		$this->headers['Content-Type'] = 'application/json';
+		$this->body['query'] = $query;
 		$this->path = "/api/as/v1/engines/$engine_name/query_suggestion";
 	}
 
@@ -44,7 +47,7 @@ class QuerySuggestion extends Request
 	 */
 	public function setFields(array $fields): self
 	{
-		$this->queryParams['types[documents][fields][]'] = $fields;
+		$this->body['types']['documents']['fields'] = $fields;
 		return $this;
 	}
 
@@ -54,7 +57,7 @@ class QuerySuggestion extends Request
 	 */
 	public function setSize(int $size): self
 	{
-		$this->queryParams['size'] = $size;
+		$this->body['size'] = $size;
 		return $this;
 	}
 }

--- a/src/AppSearch/Request/ResetSearchSettings.php
+++ b/src/AppSearch/Request/ResetSearchSettings.php
@@ -22,7 +22,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Reset search settings for the engine
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/search-settings.html#search-settings-reset
  */
 class ResetSearchSettings extends Request
 {

--- a/src/AppSearch/Request/Search.php
+++ b/src/AppSearch/Request/Search.php
@@ -23,7 +23,9 @@ use Elastic\EnterpriseSearch\Request\Request;
 
 /**
  * Allows you to search over, facet and filter your data
+ *
  * @internal
+ * @see https://www.elastic.co/guide/en/app-search/current/search.html
  */
 class Search extends Request
 {

--- a/src/AppSearch/Schema/MultiSearchData.php
+++ b/src/AppSearch/Schema/MultiSearchData.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
 
 namespace Elastic\EnterpriseSearch\AppSearch\Schema;
 
+use Elastic\EnterpriseSearch\AppSearch\Schema\SearchRequestParams;
+
 /**
  * @internal
  */
@@ -28,7 +30,7 @@ class MultiSearchData
 
 
 	/**
-	 * @param object[] $queries
+	 * @param SearchRequestParams[] $queries
 	 */
 	public function __construct(array $queries)
 	{


### PR DESCRIPTION
This PR fixes #4 moving the query parameters of App Search endpoints in the body request. This is a best practices reported in the documentation of App Search [here](https://www.elastic.co/guide/en/app-search/current/api-reference.html#overview-api-references-parameters).