### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -1,8 +1,7 @@
 = enterprise-search-php
 
-:doctype: book
-
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
 include::overview.asciidoc[]
 


### PR DESCRIPTION
I think the links are broken because we're missing a variable declaration.

Add some more shared files to try to fix it.