### PR TITLE
update curation properties to match api

### DIFF
--- a/src/AppSearch/Schema/Curation.php
+++ b/src/AppSearch/Schema/Curation.php
@@ -25,10 +25,10 @@ class Curation
 	public array $queries;
 
 	/** List of promoted document IDs */
-	public array $promotedDocIds;
+	public array $promoted;
 
 	/** List of hidden document IDs */
-	public array $hiddenDocIds;
+	public array $hidden;
 	public object $suggestion;
 
 


### PR DESCRIPTION
Noticed when I tried to create curations that the curation would be created but the promoted documents would always be empty. Come to find the Curation schema class defines the wrong properties. Updated the `Elastic\EnterpriseSearch\AppSearch\Schema\Curation` class to match the curation api.