### PR TITLE
Update connecting.asciidoc

### DIFF
--- a/docs/guide/connecting.asciidoc
+++ b/docs/guide/connecting.asciidoc
@@ -174,7 +174,7 @@ $client = new Client([
 $es = $client->enterpriseSearch();
 ----------------------------
 
-Or you can use the API Key created in the https://www.elastic.co/guide/en/kibana/master/api-keys.html#api-keys[Management > API Keys].
+Or you can use the API Key created in the {kibana-ref}/api-keys.html#api-keys[Management > API Keys].
 
 [source,php]
 ----------------------------


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/issues/2518

In particular, this PR is related to the following link issues:

````
10:11:43 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/enterprise-search-clients/php/8.0/connecting.html contains broken links to:
10:11:43 INFO:build_docs:   - en/kibana/master/api-keys.html
10:11:43 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/enterprise-search-clients/php/8.1/connecting.html contains broken links to:
10:11:43 INFO:build_docs:   - en/kibana/master/api-keys.html
10:11:43 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/enterprise-search-clients/php/8.2/connecting.html contains broken links to:
10:11:43 INFO:build_docs:   - en/kibana/master/api-keys.html
10:11:43 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/enterprise-search-clients/php/8.3/connecting.html contains broken links to:
10:11:43 INFO:build_docs:   - en/kibana/master/api-keys.html
10:11:43 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/enterprise-search-clients/php/8.4/connecting.html contains broken links to:
10:11:43 INFO:build_docs:   - en/kibana/master/api-keys.html
10:11:43 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/enterprise-search-clients/php/current/connecting.html contains broken links to:
10:11:43 INFO:build_docs:   - en/kibana/master/api-keys.html
````