### PR TITLE
Set Guzzle as default HTTP client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,11 @@
     "type" : "library",
     "require": {
         "php": "^7.4 || ^8.0",
-        "nyholm/psr7": "^1.3",
-        "elastic/transport": "^8.0.0"
+        "elastic/transport": "^8.0.0",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "guzzlehttp/guzzle": "^7.0",
         "phpstan/phpstan": "^1.8"
     },
     "autoload": {

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -18,7 +18,7 @@ use Elastic\Transport\Serializer\CsvSerializer;
 use Elastic\Transport\Serializer\JsonSerializer;
 use Elastic\Transport\Serializer\NDJsonSerializer;
 use Elastic\Transport\Serializer\TextSerializer;
-use Nyholm\Psr7\Factory\Psr17Factory;
+use GuzzleHttp\Psr7\Request as Psr7Request;
 use Psr\Http\Message\RequestInterface as MessageRequestInterface;
 
 class Request implements RequestInterface
@@ -41,22 +41,12 @@ class Request implements RequestInterface
      */
     public function getRequest(): MessageRequestInterface
     {
-        $factory = new Psr17Factory();
-
         $path = $this->path;
         if (!empty($this->queryParams)) {
            $path .= '?' . http_build_query($this->queryParams);
         }
-        $request = $factory->createRequest($this->method, $path);
-        foreach ($this->headers as $key => $value) {
-            $request = $request->withHeader($key, $value);
-        }
-        if (!empty($this->body)) {
-            $content = $this->serializeBody($this->body);
-            $stream = $factory->createStream($content);
-            $request = $request->withBody($stream);
-        }
-        return $request;
+        $content = empty($this->body) ?: $this->serializeBody($this->body);
+        return new Psr7Request($this->method, $path, $this->headers, $content);
     }
 
     /**


### PR DESCRIPTION
This PR set Guzzle as default HTTP client. This will solve some issue related to the PSR-18 autodiscovery feature of `elastic-transport-php` (es. #26 , #22). Of course, it's possible to specify a different HTTP client using the `client` options in the Client construct, as follows:
```php
use Elastic\EnterpriseSearch\Client;

$client = new Client([
    'client' => new CustomHttpLibrary(),
   // ...
]);
```
where `CustomHttpLibrary` is a new PSR-18 client library.