### PR TITLE
Fix/psr 18 issues not found library

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,36 @@ composer require elastic/enterprise-search
 The version follows the Elastic Stack version so `8.0` is compatible
 with Enterprise Search released in Elastic Stack 8.0.
 
+## PSR-18 HTTP library
+
+This project uses `elastic-transport-php` as HTTP library. This is a component that abstracts
+the usage of any PSR-18 client libraries. It uses the autodiscovery feature of [HTTPlug](http://httplug.io/)
+to find a compliant library already installed in your `vendor`. If you receive an error like
+`No PSR-18 clients found` this means you don't have any PSR-18 library installed.
+We suggest to use [Guzzle](https://github.com/guzzle/guzzle) v7+ as HTTP library.
+You can require it using composer:
+
+```
+composer require guzzlehttp/guzzle
+```
+
+If you want to be sure to use a specific HTTP library you need to pass it in the `Client`
+constructor, as follows:
+
+```php
+use Elastic\EnterpriseSearch\Client;
+
+$client = new Client([
+    'client' => new GuzzleHttp\Client,
+   // ...
+]);
+```
+
+### Guzzle v6
+
+If you want to use Guzzle v6, you need to add the [php-http/guzzle6-adapter](https://github.com/php-http/guzzle6-adapter)
+as composer requirement.
+
 ## Documentation
 
 [See the documentation](https://www.elastic.co/guide/en/enterprise-search-clients/php) for how to get started,

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
         "guzzlehttp/guzzle": "^7.0",
         "phpstan/phpstan": "^1.8"
     },
+    "suggest": {
+        "guzzlehttp/guzzle": "We suggest to use Guzzle as PSR-18 HTTP library"
+    },
     "autoload": {
         "psr-4": {
             "Elastic\\EnterpriseSearch\\": "src/"

--- a/src/Client.php
+++ b/src/Client.php
@@ -24,7 +24,7 @@ use Elastic\Transport\TransportBuilder;
 
 class Client
 {
-    const VERSION = '8.4.0';
+    const VERSION = '8.5.0';
 
     private array $config = [];
 


### PR DESCRIPTION
This PR should fix the issues #26, #31, #7. This adds information in the README about the PSR-18 client library installation and usage. Moreover, it adds a `suggest` section in `composer.json`, to use `Guzzle` as suggested PSR-18 client library,