### PR TITLE
Prevent errors when using PSR-18 clients that do not automatically decode GZIP responses

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -110,7 +110,6 @@ class Client
         if (!isset($config['meta-header']) || $config['meta-header']) {
             $transport->setElasticMetaHeader('ent', self::VERSION);
         }
-        $transport->setHeader('Accept-Encoding', 'gzip');
     }
 
     /**


### PR DESCRIPTION
This commit removes the forced `Accept-Encoding: gzip` header, as not all PSR-18 clients automatically decode/gunzip the responses. With the forced header in place, the error `Not a valid Json: Control character error, possibly incorrectly encoded` will appear when calling $request->asString(), which is a core part of decoding JSON responses.

If you use Guzzle or another more fully-featured client, you likely won't see this error, but simple PSR-18 clients that don't automatically handle the responses like Guzzle does could run into issues with the gzip'ed responses.

It would be better to handle this Accept-Encoding logic in [elastic/elastic-transport-php](https://github.com/elastic/elastic-transport-php) by adding some detection if the client automatically decodes responses (and if so, automatically adding the header there). Perhaps the [PHP-HTTP Decoder Plugin](https://docs.php-http.org/en/latest/plugins/decoder.html) would be a good place to look as well.

In any case, this package version 8.0+ do not work when httplug picks a simpler client that can't handle gzip automatically, so this change resolves that. This is not the perfect solution, as most clients probably do handle gzip'ed responses, but it is a "safer default" that allows all clients to work without special configuration.

If you are finding this PR because you are getting the `Not a valid Json...` error, it's related to this issue: https://github.com/elastic/elasticsearch-php/issues/1213 which was resolved in the main elasticsearch-php package but hasn't been resolved in this package for Enterprise Search. The quick fix, if this PR is not merged, is to specify Guzzle as the default client which is currently documented here: https://github.com/elastic/enterprise-search-php#psr-18-http-library, as your install must be detecting another HTTP client library that doesn't have all of the features that Guzzle does, so setting that manually will force Guzzle to be used.