### PR TITLE
Fix deprecated error for undeclared variable in Response.php

### DIFF
--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -36,6 +36,8 @@ class Response implements ResponseInterface, ArrayAccess
 
     protected string $asString;
 
+    protected MessageResponseInterface $response;
+
     /**
      * @throws ClientErrorResponseException if status code 4xx
      * @throws ServerErrorResponseException if status code 5xx


### PR DESCRIPTION
I just declared the `$response` variable in `Response.php` to prevent any deprecated notice, which we were getting with PHP 8.2.
Thanks