### PR TITLE
[DOCS] Fix 8.10.0 release notes

### DIFF
--- a/docs/guide/release_notes/810.asciidoc
+++ b/docs/guide/release_notes/810.asciidoc
@@ -1,4 +1,4 @@
-[[release_notes_810]]
+[[release_notes_8_10]]
 === 8.10 Release notes
 
 [discrete]

--- a/docs/guide/release_notes/index.asciidoc
+++ b/docs/guide/release_notes/index.asciidoc
@@ -4,7 +4,7 @@
 [discrete]
 === 8.x
 
-* <<release_notes_810, 8.10.0 Release Notes>>
+* <<release_notes_8_10, 8.10.0 Release Notes>>
 * <<release_notes_89, 8.9.0 Release Notes>>
 * <<release_notes_88, 8.8.0 Release Notes>>
 * <<release_notes_87, 8.7.0 Release Notes>>


### PR DESCRIPTION
**Problem:**
https://github.com/elastic/enterprise-search-php/commit/2531a7e739ee24e9733657836d50e6dd5e3ebf12 introduces release notes for 8.10.0. These notes reuse the same section id used for the 8.1.0 RNs: `[[release_notes_810]]`.

This is breaking the docs build. The docs build requires unique section ids.

**Solution:**
Update the section id for the 8.10.0 RNs.