### PR TITLE
Add the buildkite-pipeline to the catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-enterprise-search-php
+spec:
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: Enterprise Search PHP Client
+      name: enterprise-search-php
+    spec:
+      repository: elastic/enterprise-search-php
+      teams:
+        clients-team: {}
+        everyone:
+          access_level: READ_ONLY
+  owner: group:clients-team
+  type: buildkite-pipeline

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,8 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: d6fb0a12-5578-4671-a2dc-52892dd058c2
-  namespace: terrazzo-local
+  name: buildkite-pipeline-enterprise-search-php
 spec:
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -15,7 +14,8 @@ spec:
       default_branch: null
       repository: elastic/enterprise-search-php
       teams:
-        devtools-team: {}
+        devtools-team:
+          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
   owner: group:devtools-team

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,7 +1,9 @@
+---
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-pipeline-enterprise-search-php
+  name: d6fb0a12-5578-4671-a2dc-52892dd058c2
+  namespace: terrazzo-local
 spec:
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -10,10 +12,11 @@ spec:
       description: Enterprise Search PHP Client
       name: enterprise-search-php
     spec:
+      default_branch: null
       repository: elastic/enterprise-search-php
       teams:
-        clients-team: {}
+        devtools-team: {}
         everyone:
           access_level: READ_ONLY
-  owner: group:clients-team
+  owner: group:devtools-team
   type: buildkite-pipeline


### PR DESCRIPTION
This PR converts the data in
https://github.com/elastic/ci/blob/6843857da04cc0602307ed3773ecec4c9c87f4ca/terrazzo/manifests/prod/buildkite/
 into an RRE and stores it their associated repo.